### PR TITLE
Fix bad file descriptor on json output

### DIFF
--- a/httpagg.go
+++ b/httpagg.go
@@ -27,7 +27,7 @@ type options struct {
 }
 
 func AppendJSONToFile(fileName string, jsonData http.Response) {
-	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE, 0666)
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 	check(err)
 	defer f.Close()
 


### PR DESCRIPTION
Had issues with bad file descriptor or json file was not created when running load test. After adding `WRONLY` access, it fixes the issue and json + html report were properly generated for me. Hope this helps :)